### PR TITLE
Bumps to version 0.10.0 of Crystal

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ following command:
 $ heroku create myapp --buildpack https://github.com/zamith/heroku-buildpack-crystal.git
 ```
 
-In order for the buildpack to work properly you should have a `Projectfile`
+In order for the buildpack to work properly you should have a `shard.yml`
 file, as it is how it will detect that your app is a Crystal app.
 
 To learn more about using custom buildpacks in Heroku, read [their docs](https://devcenter.heroku.com/articles/third-party-buildpacks#using-a-custom-buildpack).

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.9.1/crystal-0.9.1-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.10.0/crystal-0.10.0-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 
@@ -15,7 +15,7 @@ curl -sL $CRYSTAL_URL | tar xz -C $CRYSTAL_DIR --strip-component=1
 # Build the project
 cd $BUILD_DIR
 
-if [ -f Projectfile ]; then
+if [ -f shard.yml ]; then
   echo "-----> Installing Dependencies"
   $CRYSTAL_DIR/bin/crystal deps
 fi

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -f $1/Projectfile ]; then
+if [ -f $1/shard.yml ]; then
   echo "Crystal"
   exit 0
 else


### PR DESCRIPTION
Should unblock [crystalshards#9](https://github.com/zamith/crystalshards/pull/9):
- Crystal 0.10.0 installation pack
- `shard.yml` instead of `Projectfile`
