### PR TITLE
Autodetection of shard name, plus update to 0.12.0-1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+# YAML parser from https://gist.github.com/pkuczynski/8665367
+parse_yaml() {
+   local prefix=$2
+   local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+   sed -ne "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+      }
+   }'
+}
+
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
@@ -18,7 +35,13 @@ cd $BUILD_DIR
 if [ -f shard.yml ]; then
   echo "-----> Installing Dependencies"
   $CRYSTAL_DIR/bin/crystal deps
+
+  eval $(parse_yaml shard.yml "shard_")
+
+  echo "-----> Compiling src/${shard_name}.cr (auto-detected from shard.yml)"
+  $CRYSTAL_DIR/bin/crystal build src/${shard_name}.cr --release -o app
+else
+  echo "-----> Compiling app.cr (defaulted - set name in shard.yml to override)"
+  $CRYSTAL_DIR/bin/crystal build app.cr --release
 fi
 
-echo "-----> Compiling app.cr"
-$CRYSTAL_DIR/bin/crystal build app.cr --release

--- a/bin/compile
+++ b/bin/compile
@@ -20,7 +20,7 @@ parse_yaml() {
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.11.1/crystal-0.11.1-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.12.0/crystal-0.12.0-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -36,10 +36,14 @@ if [ -f shard.yml ]; then
   echo "-----> Installing Dependencies"
   $CRYSTAL_DIR/bin/crystal deps
 
-  eval $(parse_yaml shard.yml "shard_")
-
-  echo "-----> Compiling src/${shard_name}.cr (auto-detected from shard.yml)"
-  $CRYSTAL_DIR/bin/crystal build src/${shard_name}.cr --release -o app
+  if [ -f app.cr ]; then
+    echo "-----> Compiling app.cr (overriden - app.cr exists)"
+    $CRYSTAL_DIR/bin/crystal build app.cr --release
+  else
+    eval $(parse_yaml shard.yml "shard_")
+    echo "-----> Compiling src/${shard_name}.cr (auto-detected from shard.yml)"
+    $CRYSTAL_DIR/bin/crystal build src/${shard_name}.cr --release -o app
+  fi
 else
   echo "-----> Compiling app.cr (defaulted - set name in shard.yml to override)"
   $CRYSTAL_DIR/bin/crystal build app.cr --release

--- a/bin/compile
+++ b/bin/compile
@@ -37,7 +37,7 @@ if [ -f shard.yml ]; then
   $CRYSTAL_DIR/bin/crystal deps
 
   if [ -f app.cr ]; then
-    echo "-----> Compiling app.cr (overriden - app.cr exists)"
+    echo "-----> Compiling app.cr (using old behaviour, app.cr exists - ignoring shard.yml)"
     $CRYSTAL_DIR/bin/crystal build app.cr --release
   else
     eval $(parse_yaml shard.yml "shard_")
@@ -45,7 +45,7 @@ if [ -f shard.yml ]; then
     $CRYSTAL_DIR/bin/crystal build src/${shard_name}.cr --release -o app
   fi
 else
-  echo "-----> Compiling app.cr (defaulted - set name in shard.yml to override)"
+  echo "-----> Compiling app.cr (create shard.yml to override, learn more: https://github.com/ysbaddaden/shards)"
   $CRYSTAL_DIR/bin/crystal build app.cr --release
 fi
 


### PR DESCRIPTION
@zamith this autodetects the name of the project from the `shard.yml`'s so you can use the standard `crystal init app somename .`. It's backwards compatible with the existing behavior too.
